### PR TITLE
Fix: invalid npm package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 To use npm
 
 ```bash
-npm install @capacitor/native-audio
+npm install @capacitor-community/native-audio
 ```
 
 To use yarn
 
 ```bash
-yarn add @capacitor/native-audio
+yarn add @capacitor-community/native-audio
 ```
 
 Sync native files


### PR DESCRIPTION
I"ve tried to install it, but when running the example commands, I've got error.

```
% yarn add @capacitor/native-audio
yarn add v1.21.1
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@capacitor%2fnative-audio: Not found".
```

I thinks the package name should be `@capacitor-community/native-audio`