### PR TITLE
fix: deprecated warning

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -61,15 +61,15 @@ public class NativeAudio: CAPPlugin {
                                 audioAsset?.play(time: time)
                             }
                             
-                            call.success()
+                            call.resolve()
                         } else if (asset is Int32) {
                             let audioAsset = asset as? NSNumber ?? 0
                             
                             AudioServicesPlaySystemSound(SystemSoundID(audioAsset.intValue ))
                             
-                            call.success()
+                            call.resolve()
                         } else {
-                            call.error(Constant.ErrorAssetNotFound)
+                            call.reject(Constant.ErrorAssetNotFound)
                         }
                     }
                 }
@@ -80,7 +80,7 @@ public class NativeAudio: CAPPlugin {
     @objc private func getAudioAsset(_ call: CAPPluginCall) -> AudioAsset? {
         let audioId = call.getString(Constant.AssetIdKey) ?? ""
         if audioId == "" {
-            call.error(Constant.ErrorAssetId)
+            call.reject(Constant.ErrorAssetId)
             return nil
         }
         if self.audioList.count > 0 {
@@ -89,7 +89,7 @@ public class NativeAudio: CAPPlugin {
                 return asset as? AudioAsset
             }
         }
-        call.error(Constant.ErrorAssetNotFound + " - " + audioId)
+        call.reject(Constant.ErrorAssetNotFound + " - " + audioId)
         return nil
     }
     
@@ -120,16 +120,16 @@ public class NativeAudio: CAPPlugin {
         }
 
         audioAsset.resume()
-        call.success()
+        call.resolve()
     }
     
     @objc func pause(_ call: CAPPluginCall) {
         guard let audioAsset: AudioAsset = self.getAudioAsset(call) else {
-           return
+            return
         }
 
         audioAsset.pause()
-        call.success()
+        call.resolve()
     }
     
     @objc func stop(_ call: CAPPluginCall) {
@@ -138,7 +138,7 @@ public class NativeAudio: CAPPlugin {
         do {
             try stopAudio(audioId: audioId)
         } catch {
-            call.error(Constant.ErrorAssetNotFound)
+            call.reject(Constant.ErrorAssetNotFound)
         }
     }
     
@@ -148,7 +148,7 @@ public class NativeAudio: CAPPlugin {
         }
         
         audioAsset.loop()
-        call.success()
+        call.resolve()
     }
     
     @objc func unload(_ call: CAPPluginCall) {
@@ -162,7 +162,7 @@ public class NativeAudio: CAPPlugin {
             }
         }
         
-        call.success()
+        call.resolve()
     }
     
     @objc func setVolume(_ call: CAPPluginCall) {
@@ -173,7 +173,7 @@ public class NativeAudio: CAPPlugin {
         let volume = call.getFloat(Constant.Volume) ?? 1.0
         
         audioAsset.setVolume(volume: volume as NSNumber)
-        call.success()
+        call.resolve()
     }
     
     private func preloadAsset(_ call: CAPPluginCall, isComplex complex: Bool) {
@@ -224,17 +224,14 @@ public class NativeAudio: CAPPlugin {
                             
                             AudioServicesCreateSystemSoundID(soundFileUrl, &soundId)
                             self.audioList[audioId] = NSNumber(value: Int32(soundId))
-                            
-                            call.success()
+                            call.resolve()
                         } else {
                             let audioAsset: AudioAsset = AudioAsset(owner: self, withAssetId: audioId, withPath: basePath, withChannels: channels, withVolume: volume as NSNumber?, withFadeDelay: delay)
-                            
                             self.audioList[audioId] = audioAsset
-                            
-                            call.success()
+                            call.resolve()
                         }
                     } else {
-                        call.error(Constant.ErrorAssetPath + " - " + assetPath)
+                        call.reject(Constant.ErrorAssetPath + " - " + assetPath)
                     }
                 }
             }


### PR DESCRIPTION
use new methods for capacitor plugin instead of depreacted one, it doesn't change the behaviors
`. success` to `.resolve`