### PR TITLE
Fix stops the background music (updated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ getDuration(options: { assetId: string; }) => Promise<{ duration: number; }>
 
 | Prop       | Type                 | Description          |
 | ---------- | -------------------- | -------------------- |
-| **`fade`** | <code>boolean</code> | 
-| **`focus`** | <code>boolean</code> | A bool indicating whether or not to disable mixed audio. By default - <code>false</code>
+| **`fade`** | <code>boolean</code> | A bool indicating whether or not to fade audio. By default - <code>true</code>
+| **`focus`** | <code>boolean</code> | A bool indicating whether or not to disable mixed audio. By default - <code>true</code>
 
 
 #### PreloadOptions

--- a/README.md
+++ b/README.md
@@ -331,9 +331,10 @@ getDuration(options: { assetId: string; }) => Promise<{ duration: number; }>
 
 #### ConfigureOptions
 
-| Prop       | Type                 |
-| ---------- | -------------------- |
-| **`fade`** | <code>boolean</code> |
+| Prop       | Type                 | Description          |
+| ---------- | -------------------- | -------------------- |
+| **`fade`** | <code>boolean</code> | 
+| **`focus`** | <code>boolean</code> | A bool indicating whether or not to disable mixed audio. By default - <code>false</code>
 
 
 #### PreloadOptions

--- a/android/src/main/java/com/getcapacitor/community/audio/Constant.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/Constant.java
@@ -12,6 +12,7 @@ public class Constant {
   public static final String ASSET_ID = "assetId";
   public static final String ASSET_PATH = "assetPath";
   public static final String OPT_FADE_MUSIC = "fade";
+  public static final String OPT_FOCUS_AUDIO = "focus";
   public static final String VOLUME = "volume";
   public static final String AUDIO_CHANNEL_NUM = "audioChannelNum";
   public static final String LOOP = "loop";

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -57,11 +57,13 @@ public class NativeAudio
     this.audioManager = (AudioManager) getBridge()
       .getActivity()
       .getSystemService(Context.AUDIO_SERVICE);
-    this.audioManager.requestAudioFocus(
-      this,
-      AudioManager.STREAM_MUSIC,
-      AudioManager.AUDIOFOCUS_GAIN
-    );
+    if (this.audioManager != null) {
+      this.audioManager.requestAudioFocus(
+        this,
+        AudioManager.STREAM_MUSIC,
+        AudioManager.AUDIOFOCUS_GAIN
+      );
+    }
   }
 
   @Override

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -10,6 +10,7 @@ import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_EXISTS;
 import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_ID_MISSING;
 import static com.getcapacitor.community.audio.Constant.LOOP;
 import static com.getcapacitor.community.audio.Constant.OPT_FADE_MUSIC;
+import static com.getcapacitor.community.audio.Constant.OPT_FOCUS_AUDIO;
 import static com.getcapacitor.community.audio.Constant.VOLUME;
 
 import android.Manifest;
@@ -47,22 +48,15 @@ public class NativeAudio
   private static HashMap<String, AudioAsset> audioAssetList;
   private static ArrayList<AudioAsset> resumeList;
   private boolean fadeMusic = false;
+  private AudioManager audioManager;
 
   @Override
   public void load() {
     super.load();
 
-    AudioManager audioManager = (AudioManager) getBridge()
+    this.audioManager = (AudioManager) getBridge()
       .getActivity()
       .getSystemService(Context.AUDIO_SERVICE);
-
-    if (audioManager != null) {
-      int result = audioManager.requestAudioFocus(
-        this,
-        AudioManager.STREAM_MUSIC,
-        AudioManager.AUDIOFOCUS_GAIN
-      );
-    }
   }
 
   @Override
@@ -128,6 +122,14 @@ public class NativeAudio
 
     if (call.hasOption(OPT_FADE_MUSIC)) this.fadeMusic =
       call.getBoolean(OPT_FADE_MUSIC);
+
+    if (call.hasOption(OPT_FOCUS_AUDIO) && this.audioManager != null) {
+      this.audioManager.requestAudioFocus(
+              this,
+              AudioManager.STREAM_MUSIC,
+              AudioManager.AUDIOFOCUS_GAIN
+      );
+    }
   }
 
   @PluginMethod

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -57,6 +57,11 @@ public class NativeAudio
     this.audioManager = (AudioManager) getBridge()
       .getActivity()
       .getSystemService(Context.AUDIO_SERVICE);
+    this.audioManager.requestAudioFocus(
+      this,
+      AudioManager.STREAM_MUSIC,
+      AudioManager.AUDIOFOCUS_GAIN
+    );
   }
 
   @Override
@@ -124,11 +129,15 @@ public class NativeAudio
       call.getBoolean(OPT_FADE_MUSIC);
 
     if (call.hasOption(OPT_FOCUS_AUDIO) && this.audioManager != null) {
-      this.audioManager.requestAudioFocus(
-              this,
-              AudioManager.STREAM_MUSIC,
-              AudioManager.AUDIOFOCUS_GAIN
-      );
+      if (call.getBoolean(OPT_FOCUS_AUDIO)) {
+        this.audioManager.requestAudioFocus(
+          this,
+          AudioManager.STREAM_MUSIC,
+          AudioManager.AUDIOFOCUS_GAIN
+        );
+      } else {
+        this.audioManager.abandonAudioFocus(this);
+      }
     }
   }
 

--- a/ios/Plugin/Constant.swift
+++ b/ios/Plugin/Constant.swift
@@ -8,11 +8,12 @@
 
 public class Constant {
     public static let FadeKey = "fade"
+    public static let FocusAudio = "focus"
     public static let AssetPathKey = "assetPath"
     public static let AssetIdKey = "assetId"
     public static let Volume = "volume"
     public static let Loop = "loop"
-    
+
     public static let ErrorAssetId = "Asset Id is missing"
     public static let ErrorAssetPath = "Asset Path is missing"
     public static let ErrorAssetNotFound = "Asset is not loaded"

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -196,7 +196,7 @@ public class NativeAudio: CAPPlugin {
             if (complex) {
                 volume = call.getFloat("volume") ?? 1.0
                 channels = NSNumber(value: call.getInt("channels") ?? 1)
-                delay = NSNumber(value: call.getInt("delay") ?? 0)
+                delay = NSNumber(value: call.getInt("delay") ?? 1)
                 isUrl = call.getBool("isUrl") ?? false
             } else {
                 channels = 0

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -24,24 +24,28 @@ public class NativeAudio: CAPPlugin {
         self.fadeMusic = false
 
         do {
-            try self.session.setCategory(AVAudioSession.Category.ambient)
+            try self.session.setCategory(AVAudioSession.Category.playback)
             try self.session.setActive(false)
         } catch {
-            print("Failed to ")
+            print("Failed to set session category")
         }
     }
 
     @objc func configure(_ call: CAPPluginCall) {
-        let fade: Bool = call.getBool(Constant.FadeKey) ?? false
-        let focus: Bool = call.getBool(Constant.FocusAudio) ?? false
-        if focus {
+        if let fade = call.getBool(Constant.FadeKey) {
+            self.fadeMusic = fade
+        }
+        if let focus = call.getBool(Constant.FocusAudio) {
             do {
-                try session.setCategory(AVAudioSession.Category.playback)
+                if focus {
+                    try self.session.setCategory(AVAudioSession.Category.playback)
+                } else {
+                    try self.session.setCategory(AVAudioSession.Category.ambient)
+                }
             } catch {
-                print("Failed to ")
+                print("Failed to set setCategory audio")
             }
         }
-        fadeMusic = fade
     }
 
     @objc func preload(_ call: CAPPluginCall) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/native-audio",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A native plugin for native audio engine",
   "main": "dist/plugin.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -15,6 +15,7 @@ export interface NativeAudio {
 
 export interface ConfigureOptions {
   fade?: boolean;
+  focus?: boolean;
 }
 
 export interface PreloadOptions {


### PR DESCRIPTION
Fix this issue https://github.com/capacitor-community/native-audio/issues/40

This fix has been published on NPM until it's merged:
`npm i @forgr/native-audio`

By default, audio is not mixed on android and iOS, if you need to mix it just do :
```javascript
NativeAudio.configure({focus: false});
```

## iOS explainations :
### For playback:
By default, using this category implies that your app’s audio is nonmixable—activating your session will interrupt any other audio sessions which are also nonmixable.
https://developer.apple.com/documentation/avfaudio/avaudiosession/category/1616509-playback

### For ambient:
When you use this category, audio from other apps mixes with your audio.
https://developer.apple.com/documentation/avfaudio/avaudiosession/category/1616560-ambient

## PS: 
this is a rework of the PR https://github.com/capacitor-community/native-audio/pull/42 but where the old behaviour is maintained.
