### PR TITLE
fix(ios): resolve already exist asset

### DIFF
--- a/ios/Plugin/Constant.swift
+++ b/ios/Plugin/Constant.swift
@@ -16,4 +16,5 @@ public class Constant {
     public static let ErrorAssetId = "Asset Id is missing"
     public static let ErrorAssetPath = "Asset Path is missing"
     public static let ErrorAssetNotFound = "Asset is not loaded"
+    public static let ErrorAssetExists = "Audio Asset already exists"
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -245,6 +245,8 @@ public class NativeAudio: CAPPlugin {
                     } else {
                         call.reject(Constant.ErrorAssetPath + " - " + assetPath)
                     }
+                } else {
+                    call.reject(Constant.ErrorAssetExists)
                 }
             }
         }


### PR DESCRIPTION
This will resolve exist asset when user using `preload` on an exist asset on iOS, I do use the same constant as Android error constant for easier for developer to handle their logics.