### PR TITLE
fix: Make time optional on play method

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,7 +1,7 @@
 export interface NativeAudio {
   configure(options: ConfigureOptions): Promise<void>;
   preload(options: PreloadOptions): Promise<void>;
-  play(options: { assetId: string, time: number }): Promise<void>;
+  play(options: { assetId: string, time?: number }): Promise<void>;
   pause(options: { assetId: string }): Promise<void>;
   resume(options: { assetId: string }): Promise<void>;
   loop(options: { assetId: string }): Promise<void>;


### PR DESCRIPTION
docs mention the time is optional and I've checked that native code defaults to 0 if not provided, so adjust the types accordingly 

closes https://github.com/capacitor-community/native-audio/issues/63