### PR TITLE
fix: configure method not resolving

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -121,7 +121,6 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                 this.audioManager.abandonAudioFocus(this);
             }
         }
-
         call.resolve();
     }
 

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -121,6 +121,8 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                 this.audioManager.abandonAudioFocus(this);
             }
         }
+
+        call.resolve();
     }
 
     @PluginMethod

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -46,6 +46,7 @@ public class NativeAudio: CAPPlugin {
                 print("Failed to set setCategory audio")
             }
         }
+        call.resolve()
     }
 
     @objc func preload(_ call: CAPPluginCall) {


### PR DESCRIPTION
Android configure() method is missing `call.resolve()` call.

This causes this code to wait forever:
```js
await NativeAudio.configure({ focus: false });
```