### PR TITLE
fix: Use correct defaults for configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,10 +395,10 @@ Listen for asset completed playing event
 
 #### ConfigureOptions
 
-| Prop        | Type                 | Description                                       | Default           |
-| ----------- | -------------------- | ------------------------------------------------- | ----------------- |
-| **`fade`**  | <code>boolean</code> | indicating whether or not to fade audio.          | <code>true</code> |
-| **`focus`** | <code>boolean</code> | indicating whether or not to disable mixed audio. | <code>true</code> |
+| Prop        | Type                 | Description                                       | Default            |
+| ----------- | -------------------- | ------------------------------------------------- | ------------------ |
+| **`fade`**  | <code>boolean</code> | Indicating whether or not to fade audio.          | <code>false</code> |
+| **`focus`** | <code>boolean</code> | Indicating whether or not to disable mixed audio. | <code>false</code> |
 
 
 #### PreloadOptions

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -108,10 +108,10 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
     public void configure(PluginCall call) {
         initSoundPool();
 
-        this.fadeMusic = call.getBoolean(OPT_FADE_MUSIC, true);
+        this.fadeMusic = call.getBoolean(OPT_FADE_MUSIC, false);
 
         if (this.audioManager != null) {
-            if (call.getBoolean(OPT_FOCUS_AUDIO, true)) {
+            if (call.getBoolean(OPT_FOCUS_AUDIO, false)) {
                 this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
             } else {
                 this.audioManager.abandonAudioFocus(this);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -32,19 +32,15 @@ public class NativeAudio: CAPPlugin {
     }
 
     @objc func configure(_ call: CAPPluginCall) {
-        if let fade = call.getBool(Constant.FadeKey) {
-            self.fadeMusic = fade
-        }
-        if let focus = call.getBool(Constant.FocusAudio) {
-            do {
-                if focus {
-                    try self.session.setCategory(AVAudioSession.Category.playback)
-                } else {
-                    try self.session.setCategory(AVAudioSession.Category.ambient)
-                }
-            } catch {
-                print("Failed to set setCategory audio")
+        self.fadeMusic = call.getBool(Constant.FadeKey, false)
+        do {
+            if call.getBool(Constant.FocusAudio, false) {
+                try self.session.setCategory(AVAudioSession.Category.playback)
+            } else {
+                try self.session.setCategory(AVAudioSession.Category.ambient)
             }
+        } catch {
+            print("Failed to set setCategory audio")
         }
         call.resolve()
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,13 +23,14 @@ export interface NativeAudio {
 
 export interface ConfigureOptions {
   /**
-   * indicating whether or not to fade audio.
-   * @default true
+   * Indicating whether or not to fade audio.
+   * @default false
    */
   fade?: boolean;
   /**
-   * indicating whether or not to disable mixed audio.
-   * @default true */
+   * Indicating whether or not to disable mixed audio.
+   * @default false
+   */
   focus?: boolean;
 }
 


### PR DESCRIPTION
The configure options, fade and focus were documented as being true by default, but they were false by default, so edit the docs and adjust the code to set it to false again on Android since I just changed it to true to match the docs.