### PR TITLE
Add optional `audioType` parameter to preloadAsset to play sounds as notification/ringtone/etc.

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/audio/AudioAsset.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/AudioAsset.java
@@ -14,7 +14,7 @@ public class AudioAsset {
     private String assetId;
     private NativeAudio owner;
 
-    AudioAsset(NativeAudio owner, String assetId, AssetFileDescriptor assetFileDescriptor, int audioChannelNum, float volume)
+    AudioAsset(NativeAudio owner, String assetId, AssetFileDescriptor assetFileDescriptor, int audioChannelNum, float volume, int audioType)
         throws Exception {
         audioList = new ArrayList<>();
         this.owner = owner;
@@ -25,7 +25,7 @@ public class AudioAsset {
         }
 
         for (int x = 0; x < audioChannelNum; x++) {
-            AudioDispatcher audioDispatcher = new AudioDispatcher(assetFileDescriptor, volume);
+            AudioDispatcher audioDispatcher = new AudioDispatcher(assetFileDescriptor, volume, audioType);
             audioList.add(audioDispatcher);
             if (audioChannelNum == 1) audioDispatcher.setOwner(this);
         }

--- a/android/src/main/java/com/getcapacitor/community/audio/AudioDispatcher.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/AudioDispatcher.java
@@ -25,7 +25,7 @@ public class AudioDispatcher
     private int mediaState;
     private AudioAsset owner;
 
-    public AudioDispatcher(AssetFileDescriptor assetFileDescriptor, float volume) throws Exception {
+    public AudioDispatcher(AssetFileDescriptor assetFileDescriptor, float volume, int audioType) throws Exception {
         mediaState = INVALID;
 
         mediaPlayer = new MediaPlayer();
@@ -39,7 +39,7 @@ public class AudioDispatcher
         mediaPlayer.setOnSeekCompleteListener(this);
         mediaPlayer.setAudioAttributes(
             new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setUsage(audioType)
                 .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                 .build()
         );

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -385,7 +385,11 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                     }
                 }
 
-                AudioAsset asset = new AudioAsset(this, audioId, assetFileDescriptor, audioChannelNum, (float) volume);
+                Integer audioType = call.getInt("audioType");
+                if(audioType == null) {
+                    audioType = 1; // Default to USAGE_MEDIA
+                }
+                AudioAsset asset = new AudioAsset(this, audioId, assetFileDescriptor, audioChannelNum, (float) volume, audioType);
                 audioAssetList.put(audioId, asset);
 
                 JSObject status = new JSObject();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -40,4 +40,5 @@ export interface PreloadOptions {
   volume?: number;
   audioChannelNum?: number;
   isUrl?: boolean;
+  audioType?: number;
 }


### PR DESCRIPTION
Adds an optional `audioType` parameter to `preloadAsset`, that can be used to set played audio to be a notification/ringtone/etc. sound, as per https://developer.android.com/reference/android/media/AudioAttributes

Defaults to `USAGE_MEDIA`, which was the previous hardcoded value.

Android only.