### PR TITLE
(ios) crash fix: conditionally set AVAudioSession category on load

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -24,8 +24,11 @@ public class NativeAudio: CAPPlugin {
         self.fadeMusic = false
 
         do {
+            let currentSessionCategory = self.session.category
+            if(currentSessionCategory == .record ) {
             try self.session.setCategory(AVAudioSession.Category.playback)
             try self.session.setActive(false)
+            }
         } catch {
             print("Failed to set session category")
         }


### PR DESCRIPTION
# Analysis

In the current plugin implementation for iOS, if another plugin or library uses the shared `AVAudioSession` instance, it can conflict with this plugin, leading to an app crash with an error such as this:

```
ATAudioSessionPropertyManager.mm:363   FAILED to set property 1684431725 on AVAudioSession with error Error Domain=NSOSStatusErrorDomain Code=-50 "(null)"
           AURemoteIO.cpp:1666  AUIOClient_StartIO failed (561145187)
           AVAEInternal.h:104   [AVAudioEngineGraph.mm:1549:Start: (err = PerformCommand(*ioNode, kAUStartIO, NULL, 0)): error 561145187
```           

In my case, this happened when updating to Capacitor v7, which changes how plugins are initialized at startup, and they now load earlier.
This caused a race condition between the `load()` function of this plugin and the initialization of another native audio library I'm using.

The other library is for audio conversations, so requires the [playAndRecord](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/playandrecord) AVAudioSession category to be set.
However, currently this plugin [immediately sets](https://github.com/capacitor-community/native-audio/blob/master/ios/Plugin/Plugin.swift#L27) the [playback](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/playback) category on loading.

In the race condition, the other library sets an initial category of "playbackAndRecord", then this plugin's `load()` function runs and sets the category to "playback", so when the other library tries to initialize an audio session with record/playback functionality, the category is wrong, causing the app to crash.


# Solution

My solution is to change the `load()` function of this plugin to check the current session category and only set it to "playback" if it's currently set to ["record"](https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct/record), which is the only category where playback will not work.
Any other category (e.g. `playbackAndRecord`) will allow playback.

This prevents any issues if another native class has set a different audio session category prior to this plugin initializing.