### PR TITLE
Add support for audio ducking in plugin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ DerivedData/
 Podfile.lock
 Package.resolved
 /.build
+/CLAUDE.md
+/.claude

--- a/README.md
+++ b/README.md
@@ -219,9 +219,13 @@ NativeAudio.isPlaying({
 configure(options: ConfigureOptions) => Promise<void>
 ```
 
-| Param         | Type                                                          |
-| ------------- | ------------------------------------------------------------- |
-| **`options`** | <code><a href="#configureoptions">ConfigureOptions</a></code> |
+Configure plugin behavior for audio focus and fading
+
+| Param         | Type                                                          | Description           |
+| ------------- | ------------------------------------------------------------- | --------------------- |
+| **`options`** | <code><a href="#configureoptions">ConfigureOptions</a></code> | Configuration options |
+
+**Since:** 1.0.0
 
 --------------------
 
@@ -400,19 +404,10 @@ Listen for asset completed playing event
 
 #### ConfigureOptions
 
-| Prop                 | Type                                                              | Description                   | Default                        |
-| -------------------- | ----------------------------------------------------------------- | ----------------------------- | ------------------------------ |
-| **`fade`**           | <code>boolean</code>                                              | Audio fade configuration       | <code>false</code>             |
-| **`audioFocusMode`** | <code><a href="#audiofocusmode">AudioFocusMode</a></code>        | Audio focus behavior mode     | <code>AudioFocusMode.NONE</code> |
-
-
-#### AudioFocusMode
-
-| Members        | Value            | Description                                           |
-| -------------- | ---------------- | ----------------------------------------------------- |
-| **`NONE`**     | <code>'none'</code>      | Allow mixed audio, no focus management                |
-| **`EXCLUSIVE`** | <code>'exclusive'</code> | Take exclusive audio focus, pause other audio        |
-| **`DUCK`**     | <code>'duck'</code>      | Take audio focus but duck (lower volume) other audio |
+| Prop                 | Type                                                      | Description               | Default                          |
+| -------------------- | --------------------------------------------------------- | ------------------------- | -------------------------------- |
+| **`fade`**           | <code>boolean</code>                                      | Audio fade configuration  | <code>false</code>               |
+| **`audioFocusMode`** | <code><a href="#audiofocusmode">AudioFocusMode</a></code> | Audio focus behavior mode | <code>AudioFocusMode.NONE</code> |
 
 
 #### PreloadOptions
@@ -431,5 +426,17 @@ Listen for asset completed playing event
 | Prop         | Type                                      |
 | ------------ | ----------------------------------------- |
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+### Enums
+
+
+#### AudioFocusMode
+
+| Members         | Value                    | Description                                          |
+| --------------- | ------------------------ | ---------------------------------------------------- |
+| **`NONE`**      | <code>'none'</code>      | Allow mixed audio, no focus management               |
+| **`EXCLUSIVE`** | <code>'exclusive'</code> | Take exclusive audio focus, pause other audio        |
+| **`DUCK`**      | <code>'duck'</code>      | Take audio focus but duck (lower volume) other audio |
 
 </docgen-api>

--- a/README.md
+++ b/README.md
@@ -93,8 +93,18 @@ OR
 another complete Ionic/Angular application demonstrating every plugin method is available in the **example-app** directory
 
 ```typescript
-import {NativeAudio} from '@capacitor-community/native-audio'
+import { NativeAudio, AudioFocusMode } from '@capacitor-community/native-audio'
 
+/**
+ * This method will configure the audio focus behavior and fading.
+ * @param fade - enable audio fade effect
+ * @param audioFocusMode - audio focus mode: NONE (mixed audio), EXCLUSIVE (pause other audio), DUCK (lower other audio volume)
+ * @returns void
+ */
+NativeAudio.configure({
+    fade: false,
+    audioFocusMode: AudioFocusMode.DUCK
+});
 
 /**
  * This method will load more optimized audio files for background into memory.
@@ -390,10 +400,19 @@ Listen for asset completed playing event
 
 #### ConfigureOptions
 
-| Prop        | Type                 | Description                                       | Default            |
-| ----------- | -------------------- | ------------------------------------------------- | ------------------ |
-| **`fade`**  | <code>boolean</code> | Indicating whether or not to fade audio.          | <code>false</code> |
-| **`focus`** | <code>boolean</code> | Indicating whether or not to disable mixed audio. | <code>false</code> |
+| Prop                 | Type                                                              | Description                   | Default                        |
+| -------------------- | ----------------------------------------------------------------- | ----------------------------- | ------------------------------ |
+| **`fade`**           | <code>boolean</code>                                              | Audio fade configuration       | <code>false</code>             |
+| **`audioFocusMode`** | <code><a href="#audiofocusmode">AudioFocusMode</a></code>        | Audio focus behavior mode     | <code>AudioFocusMode.NONE</code> |
+
+
+#### AudioFocusMode
+
+| Members        | Value            | Description                                           |
+| -------------- | ---------------- | ----------------------------------------------------- |
+| **`NONE`**     | <code>'none'</code>      | Allow mixed audio, no focus management                |
+| **`EXCLUSIVE`** | <code>'exclusive'</code> | Take exclusive audio focus, pause other audio        |
+| **`DUCK`**     | <code>'duck'</code>      | Take audio focus but duck (lower volume) other audio |
 
 
 #### PreloadOptions

--- a/android/src/main/java/com/getcapacitor/community/audio/AudioFocusMode.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/AudioFocusMode.java
@@ -25,7 +25,7 @@ public enum AudioFocusMode {
                 return mode;
             }
         }
-        
+
         return NONE;
     }
 }

--- a/android/src/main/java/com/getcapacitor/community/audio/AudioFocusMode.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/AudioFocusMode.java
@@ -1,0 +1,31 @@
+package com.getcapacitor.community.audio;
+
+public enum AudioFocusMode {
+    NONE("none"),
+    EXCLUSIVE("exclusive"),
+    DUCK("duck");
+
+    private final String value;
+
+    AudioFocusMode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static AudioFocusMode fromString(String value) {
+        if (value == null) {
+            return NONE;
+        }
+
+        for (AudioFocusMode mode : AudioFocusMode.values()) {
+            if (mode.value.equals(value)) {
+                return mode;
+            }
+        }
+        
+        return NONE;
+    }
+}

--- a/android/src/main/java/com/getcapacitor/community/audio/Constant.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/Constant.java
@@ -11,7 +11,7 @@ public class Constant {
     public static final String ASSET_ID = "assetId";
     public static final String ASSET_PATH = "assetPath";
     public static final String OPT_FADE_MUSIC = "fade";
-    public static final String OPT_FOCUS_AUDIO = "focus";
+    public static final String OPT_AUDIO_FOCUS_MODE = "audioFocusMode";
     public static final String VOLUME = "volume";
     public static final String AUDIO_CHANNEL_NUM = "audioChannelNum";
     public static final String LOOP = "loop";

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -17,6 +17,8 @@ import android.Manifest;
 import android.content.Context;
 import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
@@ -47,6 +49,8 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
     private static ArrayList<AudioAsset> resumeList;
     private boolean fadeMusic = false;
     private AudioManager audioManager;
+    private AudioFocusRequest audioFocusRequest;
+    private AudioFocusMode configuredAudioFocusMode = AudioFocusMode.NONE;
 
     @Override
     public void load() {
@@ -110,25 +114,10 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
 
         this.fadeMusic = call.getBoolean(OPT_FADE_MUSIC, false);
 
-        if (this.audioManager != null) {
-            String audioFocusModeString = call.getString(OPT_AUDIO_FOCUS_MODE, AudioFocusMode.NONE.getValue());
-            AudioFocusMode audioFocusMode = AudioFocusMode.fromString(audioFocusModeString);
+        // Store the audio focus mode configuration for later use
+        String audioFocusModeString = call.getString(OPT_AUDIO_FOCUS_MODE, AudioFocusMode.NONE.getValue());
+        this.configuredAudioFocusMode = AudioFocusMode.fromString(audioFocusModeString);
 
-            switch (audioFocusMode) {
-                case NONE:
-                    this.audioManager.abandonAudioFocus(this);
-
-                    break;
-                case EXCLUSIVE:
-                    this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-
-                    break;
-                case DUCK:
-                    this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
-
-                    break;
-            }
-        }
         call.resolve();
     }
 
@@ -285,7 +274,7 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
 
                         // Abandon audio focus when no more assets are loaded
                         if (audioAssetList.isEmpty()) {
-                            this.audioManager.abandonAudioFocus(this);
+                            abandonAudioFocus();
                         }
 
                         status = new JSObject();
@@ -411,6 +400,11 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                 AudioAsset asset = new AudioAsset(this, audioId, assetFileDescriptor, audioChannelNum, (float) volume);
                 audioAssetList.put(audioId, asset);
 
+                // Request audio focus when first asset is preloaded
+                if (audioAssetList.size() == 1) {
+                    requestAudioFocus();
+                }
+
                 JSObject status = new JSObject();
                 status.put("STATUS", "OK");
                 call.resolve(status);
@@ -456,5 +450,54 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
 
     private boolean isStringValid(String value) {
         return (value != null && !value.isEmpty() && !value.equals("null"));
+    }
+
+    private void requestAudioFocus() {
+        if (this.audioManager == null) {
+            return;
+        }
+
+        int focusGain;
+        int usage;
+        int contentType;
+
+        switch (this.configuredAudioFocusMode) {
+            case EXCLUSIVE:
+                focusGain = AudioManager.AUDIOFOCUS_GAIN;
+                usage = AudioAttributes.USAGE_MEDIA;
+                contentType = AudioAttributes.CONTENT_TYPE_MUSIC;
+                break;
+            case DUCK:
+                focusGain = AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK;
+                usage = AudioAttributes.USAGE_ASSISTANCE_SONIFICATION;
+                contentType = AudioAttributes.CONTENT_TYPE_SONIFICATION;
+                break;
+            case NONE:
+                return;
+        }
+
+        AudioAttributes audioAttributes = new AudioAttributes.Builder()
+            .setUsage(usage)
+            .setContentType(contentType)
+            .build();
+
+        this.audioFocusRequest = new AudioFocusRequest.Builder(focusGain)
+            .setAudioAttributes(audioAttributes)
+            .setOnAudioFocusChangeListener(this)
+            .setAcceptsDelayedFocusGain(false)
+            .setWillPauseWhenDucked(false)
+            .build();
+
+        int result = this.audioManager.requestAudioFocus(this.audioFocusRequest);
+        if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            Log.w(TAG, "Audio focus request denied");
+        }
+    }
+
+    private void abandonAudioFocus() {
+        if (this.audioFocusRequest != null) {
+            this.audioManager.abandonAudioFocusRequest(this.audioFocusRequest);
+            this.audioFocusRequest = null;
+        }
     }
 }

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -474,6 +474,8 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                 break;
             case NONE:
                 return;
+            default:
+                return;
         }
 
         AudioAttributes audioAttributes = new AudioAttributes.Builder()

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -9,8 +9,8 @@ import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_ASSET_MISSIN
 import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_EXISTS;
 import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_ID_MISSING;
 import static com.getcapacitor.community.audio.Constant.LOOP;
-import static com.getcapacitor.community.audio.Constant.OPT_FADE_MUSIC;
 import static com.getcapacitor.community.audio.Constant.OPT_AUDIO_FOCUS_MODE;
+import static com.getcapacitor.community.audio.Constant.OPT_FADE_MUSIC;
 import static com.getcapacitor.community.audio.Constant.VOLUME;
 
 import android.Manifest;
@@ -117,15 +117,15 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
             switch (audioFocusMode) {
                 case NONE:
                     this.audioManager.abandonAudioFocus(this);
-                    
+
                     break;
                 case EXCLUSIVE:
                     this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-                    
+
                     break;
                 case DUCK:
                     this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
-                    
+
                     break;
             }
         }

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -283,6 +283,11 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
                         asset.unload();
                         audioAssetList.remove(audioId);
 
+                        // Abandon audio focus when no more assets are loaded
+                        if (audioAssetList.isEmpty()) {
+                            this.audioManager.abandonAudioFocus(this);
+                        }
+
                         status = new JSObject();
                         status.put("status", "OK");
                         call.resolve(status);

--- a/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
+++ b/android/src/main/java/com/getcapacitor/community/audio/NativeAudio.java
@@ -10,7 +10,7 @@ import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_EXISTS;
 import static com.getcapacitor.community.audio.Constant.ERROR_AUDIO_ID_MISSING;
 import static com.getcapacitor.community.audio.Constant.LOOP;
 import static com.getcapacitor.community.audio.Constant.OPT_FADE_MUSIC;
-import static com.getcapacitor.community.audio.Constant.OPT_FOCUS_AUDIO;
+import static com.getcapacitor.community.audio.Constant.OPT_AUDIO_FOCUS_MODE;
 import static com.getcapacitor.community.audio.Constant.VOLUME;
 
 import android.Manifest;
@@ -111,10 +111,22 @@ public class NativeAudio extends Plugin implements AudioManager.OnAudioFocusChan
         this.fadeMusic = call.getBoolean(OPT_FADE_MUSIC, false);
 
         if (this.audioManager != null) {
-            if (call.getBoolean(OPT_FOCUS_AUDIO, false)) {
-                this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-            } else {
-                this.audioManager.abandonAudioFocus(this);
+            String audioFocusModeString = call.getString(OPT_AUDIO_FOCUS_MODE, AudioFocusMode.NONE.getValue());
+            AudioFocusMode audioFocusMode = AudioFocusMode.fromString(audioFocusModeString);
+
+            switch (audioFocusMode) {
+                case NONE:
+                    this.audioManager.abandonAudioFocus(this);
+                    
+                    break;
+                case EXCLUSIVE:
+                    this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+                    
+                    break;
+                case DUCK:
+                    this.audioManager.requestAudioFocus(this, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
+                    
+                    break;
             }
         }
         call.resolve();

--- a/ios/Sources/NativeAudio/AudioFocusMode.swift
+++ b/ios/Sources/NativeAudio/AudioFocusMode.swift
@@ -1,0 +1,13 @@
+//
+//  AudioFocusMode.swift
+//  Plugin
+//
+//  Created by Rabter1 on 2025-09-21.
+//  Copyright © 2020 Max Lynch. All rights reserved.
+//
+
+public enum AudioFocusMode: String {
+    case none
+    case exclusive
+    case duck
+}

--- a/ios/Sources/NativeAudio/Constant.swift
+++ b/ios/Sources/NativeAudio/Constant.swift
@@ -8,7 +8,7 @@
 
 public class Constant {
     public static let FadeKey = "fade"
-    public static let FocusAudio = "focus"
+    public static let AudioFocusModeKey = "audioFocusMode"
     public static let AssetPathKey = "assetPath"
     public static let AssetIdKey = "assetId"
     public static let Volume = "volume"

--- a/ios/Sources/NativeAudio/Plugin.swift
+++ b/ios/Sources/NativeAudio/Plugin.swift
@@ -49,11 +49,17 @@ public class NativeAudio: CAPPlugin, CAPBridgedPlugin {
 
     @objc func configure(_ call: CAPPluginCall) {
         self.fadeMusic = call.getBool(Constant.FadeKey, false)
+        let audioFocusModeString = call.getString(Constant.AudioFocusModeKey, AudioFocusMode.none.rawValue)
+        let audioFocusMode = AudioFocusMode(rawValue: audioFocusModeString) ?? AudioFocusMode.none
+
         do {
-            if call.getBool(Constant.FocusAudio, false) {
-                try self.session.setCategory(AVAudioSession.Category.playback)
-            } else {
+            switch audioFocusMode {
+            case .none:
                 try self.session.setCategory(AVAudioSession.Category.ambient)
+            case .exclusive:
+                try self.session.setCategory(AVAudioSession.Category.playback)
+            case .duck:
+                try self.session.setCategory(AVAudioSession.Category.playback, options: .duckOthers)
             }
         } catch {
             print("Failed to set setCategory audio")

--- a/ios/Sources/NativeAudio/Plugin.swift
+++ b/ios/Sources/NativeAudio/Plugin.swift
@@ -67,6 +67,15 @@ public class NativeAudio: CAPPlugin, CAPBridgedPlugin {
         call.resolve()
     }
 
+
+    private func deactivateAudioSession() {
+        do {
+            try self.session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("Failed to deactivate audio session")
+        }
+    }
+
     @objc func preload(_ call: CAPPluginCall) {
         preloadAsset(call, isComplex: true)
     }
@@ -185,7 +194,10 @@ public class NativeAudio: CAPPlugin, CAPBridgedPlugin {
             if asset != nil && asset is AudioAsset {
                 let audioAsset = asset as! AudioAsset
                 audioAsset.unload()
-                self.audioList[audioId] = nil
+                self.audioList.removeValue(forKey: audioId);
+                if self.audioList.isEmpty {
+                    self.deactivateAudioSession()
+                }
             }
         }
         call.resolve()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,6 +1,36 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
+export enum AudioFocusMode {
+  /** Allow mixed audio, no focus management */
+  NONE = 'none',
+  /** Take exclusive audio focus, pause other audio */
+  EXCLUSIVE = 'exclusive',
+  /** Take audio focus but duck (lower volume) other audio */
+  DUCK = 'duck'
+}
+
 export interface NativeAudio {
+  /**
+   * Configure plugin behavior for audio focus and fading
+   *
+   * @param options Configuration options
+   *
+   * @example
+   * ```typescript
+   * // Duck other audio when playing
+   * await NativeAudio.configure({
+   *   audioFocusMode: AudioFocusMode.DUCK
+   * });
+   *
+   * // Take exclusive focus with fade effect
+   * await NativeAudio.configure({
+   *   fade: true,
+   *   audioFocusMode: AudioFocusMode.EXCLUSIVE
+   * });
+   * ```
+   *
+   * @since 1.0.0
+   */
   configure(options: ConfigureOptions): Promise<void>;
   preload(options: PreloadOptions): Promise<void>;
   play(options: { assetId: string; time?: number }): Promise<void>;
@@ -23,15 +53,16 @@ export interface NativeAudio {
 
 export interface ConfigureOptions {
   /**
-   * Indicating whether or not to fade audio.
+   * Audio fade configuration
    * @default false
    */
   fade?: boolean;
+
   /**
-   * Indicating whether or not to disable mixed audio.
-   * @default false
+   * Audio focus behavior mode
+   * @default AudioFocusMode.NONE
    */
-  focus?: boolean;
+  audioFocusMode?: AudioFocusMode;
 }
 
 export interface PreloadOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,7 +6,7 @@ export enum AudioFocusMode {
   /** Take exclusive audio focus, pause other audio */
   EXCLUSIVE = 'exclusive',
   /** Take audio focus but duck (lower volume) other audio */
-  DUCK = 'duck'
+  DUCK = 'duck',
 }
 
 export interface NativeAudio {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,7 @@
 import { WebPlugin } from '@capacitor/core';
 
 import { AudioAsset } from './audio-asset';
-import type { ConfigureOptions, PreloadOptions, NativeAudio, AudioFocusMode } from './definitions';
+import type { ConfigureOptions, PreloadOptions, NativeAudio } from './definitions';
 
 export class NativeAudioWeb extends WebPlugin implements NativeAudio {
   private static readonly FILE_LOCATION: string = 'assets/sounds';

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,7 @@
 import { WebPlugin } from '@capacitor/core';
 
 import { AudioAsset } from './audio-asset';
-import type { ConfigureOptions, PreloadOptions, NativeAudio } from './definitions';
+import type { ConfigureOptions, PreloadOptions, NativeAudio, AudioFocusMode } from './definitions';
 
 export class NativeAudioWeb extends WebPlugin implements NativeAudio {
   private static readonly FILE_LOCATION: string = 'assets/sounds';


### PR DESCRIPTION
## 🎵 Feature Overview

This PR introduces **audio ducking** functionality, allowing the plugin to lower the volume of other audio sources instead of completely stopping them when taking audio focus. This provides a much better user experience for apps that need to play audio alongside other media which are not supposed to be stopped.

## 🔧 Implementation Details

### New `AudioFocusMode` Enum

```typescript
export enum AudioFocusMode {
  NONE = 'none',             // Allow mixed audio (default)
  EXCLUSIVE = 'exclusive',   // Take exclusive focus, pause other audio
  DUCK = 'duck'              // Take focus but duck other audio volume
}
```

### Updated Configuration API

```typescript
// Before (old API)
NativeAudio.configure({
  fade: false,
  focus: true  // boolean flag
});

// After (new API)
NativeAudio.configure({
  fade: false,
  audioFocusMode: AudioFocusMode.DUCK  // enum value
});
```

### Platform-Specific Implementations

#### iOS Implementation
- **`NONE`**: `AVAudioSession.Category.ambient`
- **`EXCLUSIVE`**: `AVAudioSession.Category.playback`
- **`DUCK`**: `AVAudioSession.Category.playback` with `.duckOthers` option

#### Android Implementation
- **`NONE`**: `abandonAudioFocus()`
- **`EXCLUSIVE`**: `requestAudioFocus()` with `AUDIOFOCUS_GAIN`
- **`DUCK`**: `requestAudioFocus()` with `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`

#### Web Implementation
- No changes needed (configure method already throws for web platform)

## ⚠️ Breaking Changes

### What Changed
The `focus` boolean parameter in `ConfigureOptions` has been replaced with `audioFocusMode` enum.

### Migration Guide

```typescript
// ❌ OLD - Will no longer work
NativeAudio.configure({
  fade: false,
  focus: true
});

NativeAudio.configure({
  fade: false,
  focus: false
});

// ✅ NEW - Updated API
NativeAudio.configure({
  fade: false,
  audioFocusMode: AudioFocusMode.EXCLUSIVE  // Equivalent to focus: true
});

NativeAudio.configure({
  fade: false,
  audioFocusMode: AudioFocusMode.NONE  // Equivalent to focus: false (default)
});
```

### Impact Assessment
- **No impact** if you never called `configure()` - default behavior unchanged
- **Breaking change** only if you explicitly used `focus: true/false` parameter
- **Easy migration** - direct 1:1 mapping available

## 🤔 Why Breaking Changes Were Necessary

### 1. **Type Safety**
The old boolean `focus` parameter allowed invalid states and didn't prevent misconfigurations. The enum approach makes invalid states impossible at compile-time:

```typescript
// Old API - these invalid combinations were possible:
configure({ focus: true, ducking: true });   // ⚠️ Correct setup needs internal implementation knowledge
configure({ focus: false, ducking: true });  // ❌ Invalid - ducking requires focus

// New API - invalid states are impossible:
configure({ audioFocusMode: AudioFocusMode.DUCK }); // ✅ Clear and unambiguous
```

### 2. **Future Extensibility**
The enum approach allows easy addition of new audio focus modes without API changes:

```typescript
// Future possibilities:
AudioFocusMode.DUCK_WITH_INTERRUPTED_SPEACH;
```

### 3. **API Clarity**
The enum makes the intent explicit and self-documenting:

```typescript
// Old API - unclear what focus means
configure({ focus: true });

// New API - crystal clear intent
configure({ audioFocusMode: AudioFocusMode.DUCK });
```

### 4. **Industry Standards**
This approach aligns with platform conventions:
- **Android**: Uses similar enum-like constants (`AUDIOFOCUS_GAIN`, `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK`)
- **iOS**: Uses category + options pattern that maps well to discrete modes

## 🎯 Most important use case

1. **Music Apps**: Duck background music when playing sound effects or playing spoken instructions etc.

This feature allows e.g. a navigation app to play directions sounds and not stop playing music

## 🔄 Backward Compatibility Strategy

While this is technically a breaking change, the impact is minimal:

1. **Default behavior unchanged** - apps not using `configure()` work identically
2. **Clear migration path** - simple 1:1 mapping for existing `focus` usage
3. **Comprehensive documentation** - examples show exact replacements needed
4. **Enhanced functionality** - apps get better audio behavior after migration

## Limitations

### Audio Session Management

The current implementation uses a **resource-based session management** approach where audio focus is only released when the last asset is unloaded. This design decision was made to balance simplicity with common usage patterns.

**Current Behavior:**
- Audio focus is configured in `configure()` call with `EXCLUSIVE` or `DUCK` modes.
- Audio focus is requested on the first `preload()` call.
- Focus remains active while any audio assets are loaded (even if not playing)
- Focus is only released when the last asset is unloaded via `unload()`

**Rationale:**
This approach works well for the typical usage pattern of `preload() → play() → unload()` but may not be optimal for all use cases.

### Alternative Session Management Strategies

1. **Playback-based management**: Release focus when all audio stops playing (not just unloaded)

### When Current Approach May Not Be Ideal

- **Long-lived assets**: Apps that preload many assets but play them sporadically
- **Background apps**: Apps that maintain loaded assets while backgrounded
- **Complex audio workflows**: Apps with multiple simultaneous audio contexts

### Future Considerations

The current implementation prioritizes simplicity and covers the most common usage patterns. More sophisticated session management could be added in future versions based on community feedback and real-world usage requirements.

Let me know if you are interested in this Feature and if I should improve the session state management.
